### PR TITLE
We don't use GitHub Discussions, remove its link from the issue creation dialog

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: 💬 SciPy India Zulip
     url: https://scipyindia.zulipchat.com/join/4mesdxfbbpl4titgtdzx4iwv/
     about: SciPy India's Zulip chat invite link
-  - name: Discussion Forum
-    url: https://github.com/orgs/SciPy-India/discussions
-    about: Use the forum to ask questions about the upcoming events, help us with Sponsorship, or anything else.
+  # - name: Discussion Forum
+  #   url: https://github.com/orgs/SciPy-India/discussions
+  #   about: Use the forum to ask questions about the upcoming events, help us with Sponsorship, or anything else.


### PR DESCRIPTION
We already point to Zulip, so this should be fine to remove.