### PR TITLE
Pause proposal submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/talk-proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yaml
@@ -8,6 +8,9 @@ body:
         > [!NOTE]
         > Our online community calls are currently paused. Please check our social media handles or [Zulip](https://scipyindia.zulipchat.com/) for updates on when they will resume. In the meantime, consider submitting to our in-person events if you're able to attend them.**
 
+        > [!WARNING]
+        > We've received enough proposals for our upcoming meetup and submissions are paused for now. If you'd like your proposal to be considered for a future meetup, feel free to submit anyway, though do expect a delayed response.
+
         ---
 
         The above GitHub issue title will be used as your talk/session title. Keep it clear and concise. Example: "Talk: Optimising research pipelines with scientific machine learning".

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome! This repository serves to coordinate submissions and reviews of proposals for the SciPy India Community Calls.
 
 > [!WARNING]
-> We've received enough proposals for our upcoming meetup and submissions are paused for now.
+> We've received enough proposals for our upcoming [meetup](https://sci-py-rs.scipy.in/) and submissions are paused for now.
 
 If you have a proposal to share, please submit it at: https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Welcome! This repository serves to coordinate submissions and reviews of proposals for the SciPy India Community Calls.
 
+> [!WARNING]
+> We've received enough proposals for our upcoming meetup and submissions are paused for now.
+
 If you have a proposal to share, please submit it at: https://github.com/scipy-india/proposal-reviewing/issues/new?template=talk-proposal.yaml
 
 Thank you :)


### PR DESCRIPTION
We've hit capacity for the upcoming meetup (see #48, #49). Adds a warning admonition to the proposal template and README so new submitters know to expect a delay.